### PR TITLE
Fix orbs ruby version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  ruby: circleci/ruby@0.1.2 
+  ruby: circleci/ruby@2.1.1
 
 jobs:
   build:


### PR DESCRIPTION
"ci/circleci build" doesn't report any status.

See: https://circleci.com/developer/orbs/orb/circleci/ruby