### PR TITLE
Pending migrations command ignores data migrations

### DIFF
--- a/lib/obs_deploy/check_diff.rb
+++ b/lib/obs_deploy/check_diff.rb
@@ -43,12 +43,6 @@ module ObsDeploy
       GitDiffParser.parse(github_diff).files.any? { |f| f.match?(%r{db/data}) }
     end
 
-    def data_migrations
-      return [] unless data_migration?
-
-      GitDiffParser.parse(github_diff).files.select { |f| f =~ %r{db/data} }
-    end
-
     def migrations
       return [] unless migration?
 

--- a/lib/obs_deploy/cli/commands/get_pending_migration.rb
+++ b/lib/obs_deploy/cli/commands/get_pending_migration.rb
@@ -18,13 +18,12 @@ module ObsDeploy
           end
 
           migrations = ObsDeploy::CheckDiff.new(server: url, target_server: targeturl).migrations
-          data_migrations = ObsDeploy::CheckDiff.new(server: url, target_server: targeturl).data_migrations
 
-          if migrations.empty? && data_migrations.empty?
+          if migrations.empty?
             puts 'No pending migrations'
             exit(0)
           else
-            puts migrations + data_migrations
+            puts migrations
             exit(1)
           end
         end

--- a/spec/check_diff_spec.rb
+++ b/spec/check_diff_spec.rb
@@ -61,7 +61,6 @@ RSpec.describe ObsDeploy::CheckDiff do
       let(:running_commit) { '2392177' }
       let(:package_commit) { '8c6783b' }
       it { expect(check_diff.migration?).to be true }
-      it { expect(check_diff.data_migrations).not_to be_empty }
     end
   end
 
@@ -103,25 +102,6 @@ RSpec.describe ObsDeploy::CheckDiff do
         end
         it { expect(check_diff.migration?).to be true }
       end
-    end
-  end
-
-  describe '#data_migrations' do
-    subject { check_diff.data_migrations }
-
-    context 'no pending migration' do
-      let(:diff_url) { "https://github.com/openSUSE/open-build-service/compare/#{running_commit}...#{package_commit}.diff" }
-      let(:fixture_file) { File.new('spec/fixtures/github_diff_with_data_migration.txt') }
-      let(:running_commit) { 'bc7f6c0' }
-      let(:package_commit) { '554e943' }
-      before do
-        allow(check_diff).to receive(:obs_running_commit).and_return(running_commit)
-        allow(check_diff).to receive(:package_commit).and_return(package_commit)
-        stub_request(:get, diff_url).to_return(fixture_file)
-      end
-
-      it { expect(subject).not_to be_empty }
-      it { expect(subject).to include('src/api/db/data/20200424080753_generate_web_notifications.rb') }
     end
   end
 


### PR DESCRIPTION
We don't want to hijack the deployment window when running long data migrations on production for several reasons.
To do that, we need to deploy the code without running the data migrations first and then log into the server and run the data migrations by hand. But now, when deploying without running the migrations it detects the data migrations and blocks the deployment.
This change allows us to deploy the code and the schema changes, but allow us to run the data migrations when we see fit, that is, outside of the deployment window.