### PR TITLE
Fix permission errors on dev container under SELinux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
 docker-dev:
 	docker build -f Dockerfile.dev -t $(USER)/obs_deploy_dev .
-	docker run --rm -it -v "$(HOME)/.ssh:/tmp/.ssh:ro" -v "$(PWD):/obs_deploy" $(USER)/obs_deploy_dev bash
+	docker run --rm -it -v "$(HOME)/.ssh:/tmp/.ssh:ro,Z" -v "$(PWD):/obs_deploy:Z" $(USER)/obs_deploy_dev bash


### PR DESCRIPTION
Under SELinux systems the volume mountings fail due to permission errors